### PR TITLE
Modificato modulo 'l10n_it_intrastat':

### DIFF
--- a/oca/l10n-italy/l10n_it_intrastat/models/account.py
+++ b/oca/l10n-italy/l10n_it_intrastat/models/account.py
@@ -244,8 +244,10 @@ class account_invoice_line(models.Model):
             country_payment_id = \
                 self.invoice_id.partner_id.country_id.id
         elif self.invoice_id.type in ('in_invoice', 'in_refund'):
+            #country_payment_id = \
+            #    self.invoice_id.company_id.partner_id.country_id.id
             country_payment_id = \
-                self.invoice_id.company_id.partner_id.country_id.id
+                self.invoice_id.partner_id.country_id.id                
         res.update({'country_payment_id': country_payment_id})
         #Invoice Number
         invoice_number = False


### PR DESCRIPTION
- Nella generazione degli statement intrastat, per acquisti, la nazione di pagamento non è più quella propria dell'azienda ma quella del partner fornitore.