### PR TITLE
Modificato modulo 'account_makeover' in stampa sollecito di pagamento:

### DIFF
--- a/isa-srl/accounting/account_makeover/report/__init__.py
+++ b/isa-srl/accounting/account_makeover/report/__init__.py
@@ -19,6 +19,4 @@
 #
 ##############################################################################
 
-import models
-import wizard
-import report
+import account_print_overdue

--- a/isa-srl/accounting/account_makeover/report/account_print_overdue.py
+++ b/isa-srl/accounting/account_makeover/report/account_print_overdue.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import time
+
+from openerp.report import report_sxw
+from openerp.osv import osv
+
+
+class Overdue(report_sxw.rml_parse):
+    def __init__(self, cr, uid, name, context):
+        super(Overdue, self).__init__(cr, uid, name, context=context)
+        ids = context.get('active_ids')
+        partner_obj = self.pool['res.partner']
+        docs = partner_obj.browse(cr, uid, ids, context)
+
+        due = {}
+        paid = {}
+        mat = {}
+
+        for partner in docs:
+            due[partner.id] = reduce(lambda x, y: x + ((y['account_id']['type'] == 'receivable' and y['debit'] or 0) or (y['account_id']['type'] == 'payable' and y['credit'] * -1 or 0)), self._lines_get(partner), 0)
+            paid[partner.id] = reduce(lambda x, y: x + ((y['account_id']['type'] == 'receivable' and y['credit'] or 0) or (y['account_id']['type'] == 'payable' and y['debit'] * -1 or 0)), self._lines_get(partner), 0)
+            mat[partner.id] = reduce(lambda x, y: x + (y['debit'] - y['credit']), filter(lambda x: x['date_maturity'] < time.strftime('%Y-%m-%d'), self._lines_get(partner)), 0)
+
+        addresses = self.pool['res.partner']._address_display(cr, uid, ids, None, None)
+        self.localcontext.update({
+            'docs': docs,
+            'time': time,
+            'getLines': self._lines_get,
+            'tel_get': self._tel_get,
+            'message': self._message,
+            'due': due,
+            'paid': paid,
+            'mat': mat,
+            'addresses': addresses
+        })
+        self.context = context
+
+    def _tel_get(self,partner):
+        if not partner:
+            return False
+        res_partner = self.pool['res.partner']
+        addresses = res_partner.address_get(self.cr, self.uid, [partner.id], ['invoice'])
+        adr_id = addresses and addresses['invoice'] or False
+        if adr_id:
+            adr=res_partner.read(self.cr, self.uid, [adr_id])[0]
+            return adr['phone']
+        else:
+            return partner.phone or False
+        return False
+
+    def _lines_get(self, partner, flag = 0):
+        res = []
+        partially_reconciled = {}
+        
+        moveline_obj = self.pool['account.move.line']
+        movelines = moveline_obj.search(self.cr, self.uid,
+                [('partner_id', '=', partner.id),
+                    ('state', '<>', 'draft'), ('reconcile_id', '=', False), ('account_id.type', 'in', ['receivable','payable'])])
+        movelines = moveline_obj.browse(self.cr, self.uid, movelines)
+        if flag == 0:
+            return movelines
+        
+        for line in movelines:
+            if line.reconcile_partial_id:
+                if line.reconcile_partial_id.id not in partially_reconciled:
+                    partially_reconciled[line.reconcile_partial_id.id] = []
+                partially_reconciled[line.reconcile_partial_id.id].append(line)
+            else:
+                item = {}
+                item['date'] = line.move_id.document_date
+                item['name'] = line.move_id.name
+                item['ref'] = line.ref
+                item['date_maturity'] = line.date_maturity
+                item['type'] = line.account_id.type
+                item['debit'] = line.debit
+                item['credit'] = line.credit
+                item['blocked'] = line.blocked
+                res.append(item)
+                
+        for key in partially_reconciled.keys():
+            item = {'credit': 0.0, 'debit':0.0}
+            for line in partially_reconciled[key]:
+                if (line.account_id.type == 'receivable' and line.debit > 0) or (line.account_id.type == 'payable' and line.credit > 0):
+                    item['date'] = line.move_id.document_date
+                    item['name'] = line.move_id.name
+                    item['ref'] = line.ref
+                    item['date_maturity'] = line.date_maturity
+                    item['type'] = line.account_id.type
+                    item['debit'] += line.debit
+                    item['credit'] += line.credit
+                    item['blocked'] = line.blocked
+                else:
+                    item['debit'] += line.debit
+                    item['credit'] += line.credit 
+            res.append(item)
+        
+        return res
+
+    def _message(self, obj, company):
+        company_pool = self.pool['res.company']
+        message = company_pool.browse(self.cr, self.uid, company.id, {'lang':obj.lang}).overdue_msg
+        return message.split('\n')
+
+
+class report_overdue(osv.AbstractModel):
+    _name = 'report.account.report_overdue'
+    _inherit = 'report.abstract_report'
+    _template = 'account.report_overdue'
+    _wrapped_report_class = Overdue
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/isa-srl/accounting/account_makeover/views/report_overdue.xml
+++ b/isa-srl/accounting/account_makeover/views/report_overdue.xml
@@ -4,18 +4,9 @@
 	
 <template id="report_overdue_document" inherit_id="account.report_overdue_document">   
 
-    <xpath expr="//span[@t-field='line.date']" position="replace">
-	    <span t-field="line.move_id.document_date"/>
-    </xpath>	
-    
-    <xpath expr="//span[@t-field='line.name']" position="replace">
-	    <span t-field="line.move_id.name"/>
-    </xpath>	    
-    
     <xpath expr="//th[text() = 'Ref']" position="replace" />
 
-    <xpath expr="//span[@t-field='line.ref']/.." position='replace'/>
-
+   	
     <xpath expr="//strong[text() = 'Sub-Total :']/../../td[@colspan='3']" position="attributes">
     	<attribute name="colspan">2</attribute>
     </xpath>
@@ -27,6 +18,45 @@
     <xpath expr="//th[text() = 'Description']" position="replace">
     	<th>Numero Fattura</th>
     </xpath>      
+    
+	<xpath expr="//tr[@t-foreach='getLines(o)']" position="replace">
+	    <tr t-foreach="getLines(o,1)" t-as="line">
+	        <td>
+	            <span t-esc="line['date']"/>
+	        </td>
+	        <td>
+	            <span t-esc="line['name']"/>
+	        </td>
+	        <td>
+	            <span t-esc="line['date_maturity']"/>
+	        </td>
+	        <td class="text-right">
+	            <t t-if="line['type'] == 'receivable'">
+	                <span t-esc="formatLang(line['debit'])"/>
+	            </t>
+	            <t t-if="line['type'] == 'payable'">
+	                <span t-esc="formatLang(line['credit'] * -1)"/>
+	            </t>
+	        </td>
+	        <td class="text-right">
+	            <t t-if="line['type'] == 'receivable'">
+	                <span t-esc="formatLang(line['credit'])"/>
+	            </t>
+	            <t t-if="line['type'] == 'payable'">
+	                <span t-esc="formatLang(line['debit'] * -1)"/>
+	            </t>
+	        </td>
+	        <td class="text-right">
+	            <t t-if="time.strftime('%Y-%m-%d') &gt; line['date_maturity']">
+	                <span t-esc="formatLang(line['debit'] - line['credit'], currency_obj=res_company.currency_id)"/>
+	            </t>
+	        </td>
+	        <td>
+	            <span t-if="line['blocked']">x</span>
+	        </td>
+	    </tr>		
+	</xpath>    
+    
 
 </template>    
     


### PR DESCRIPTION
- Modificato il parser in modo da raggruppare le righe contabili da stampare in base al riferimento di riconciliazione (in pratica, tutti i movimenti con la stessa riconciliazione sono raggruppati in una riga che mostra sia quanto resta da pagare, sia quanto già parzialmente riconciliato);