### PR TITLE
Modificato modulo 'account_due_date_report_webkit':

### DIFF
--- a/isa-srl/accounting/account_due_date_report_webkit/report/template_due_list.mako
+++ b/isa-srl/accounting/account_due_date_report_webkit/report/template_due_list.mako
@@ -82,8 +82,8 @@
                         <div class="act_as_thead">
                             <div class="act_as_row labels">
                                 <div class="act_as_cell first_column" style="width: 70px;">${_('DATA SCADENZA')}</div>                               
-                                <div class="act_as_cell" style="width: 90px;">${_('DOCUMENTO')}</div>
-                                <div class="act_as_cell" style="width: 70px;">${_('DATA DOCUMENTO')}</div>
+                                <div class="act_as_cell" style="width: 90px;">${_('FATTURA')}</div>                                
+                                <div class="act_as_cell" style="width: 70px;">${_('DATA FATTURA')}</div>
                                 <div class="act_as_cell" style="width: 100px;">${_('TOTALE DOCUMENTO')}</div>
                                 <div class="act_as_cell" style="width: 70px;">
                                 	%if get_mode():
@@ -125,12 +125,14 @@
 			                                <div class="act_as_cell" style="width: 70px; text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],0,0):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% totalscaduto = totalscaduto + t %>
+													%if t > 0:
+														<% totalscaduto = totalscaduto + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -138,12 +140,14 @@
 			                                <div class="act_as_cell" style="width: 70px; text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],0,30):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total30 = total30 + t %>
+													%if t > 0:
+														<% total30 = total30 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -151,12 +155,14 @@
 			                                <div class="act_as_cell" style="width: 70px; text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],30,60):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total60 = total60 + t %>
+													%if t > 0:
+														<% total60 = total60 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -164,12 +170,14 @@
 			                                <div class="act_as_cell" style="width: 70px;  text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],60,90):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total90 = total90 + t %>
+													%if t > 0:
+														<% total90 = total90 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -177,12 +185,14 @@
 			                                <div class="act_as_cell" style="width: 70px;  text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],90,120):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total120 = total120 + t %>
+													%if t > 0:
+														<% total120 = total120 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -190,12 +200,14 @@
 			                                <div class="act_as_cell" style="width: 70px;  text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],120,150):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total150 = total150 + t %>
+													%if t > 0:
+														<% total150 = total150 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -203,12 +215,14 @@
 			                                <div class="act_as_cell" style="width: 70px;  text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],150,180):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% total180 = total180 + t %>
+													%if t > 0:
+														<% total180 = total180 + t %>
+													%endif
 												%else:
 													<br />
 												%endif
@@ -216,12 +230,14 @@
 			                                <div class="act_as_cell" style="width: 70px;  text-align: right; padding-right: 20px;">
 												%if get_maturity(line.date_maturity,data["form"]["date_maturity"],180,0):
 													%if line.reconcile_ref:
-														<% t = get_residual(line.reconcile_ref) %>
+														<% t = get_residual(line.reconcile_ref,line) %>
 													%else:
 														<% t = line.debit-line.credit %>
 													%endif
 													<div>${t}</div>
-													<% totaloltre = totaloltre + t %>
+													%if t > 0:
+														<% totaloltre = totaloltre + t %>
+													%endif
 												%else:
 													<br />
 												%endif

--- a/isa-srl/accounting/account_due_date_report_webkit/wizard/due_list.py
+++ b/isa-srl/accounting/account_due_date_report_webkit/wizard/due_list.py
@@ -28,14 +28,16 @@ class due_list(orm.TransientModel):
                                   required=True),
         'print_customers': fields.boolean('All Customers'),
         'print_suppliers': fields.boolean('All Suppliers'),
-        'type': fields.selection([('debit','Cliente'),('credit','Fornitore')],'Tipo Scadenza'),
-        'all_partner': fields.boolean('Tutti i partner',default = True)
+        'target_move': fields.selection([('posted', 'All Posted Entries'),
+                                         ('all', 'All Entries'),
+                                        ], 'Target Moves', required=True),        
     }
     _defaults = {
         'company_id': lambda self, cr, uid, c: self.pool.get('res.company')._company_default_get(cr, uid, context=c),        
         'date_maturity': fields.date.context_today,
         'partner_ids' : _get_partner_ids,
         'mode':'matured',
+        'target_move': 'posted',
     }
 
     def print_report_pdf(self, cr, uid, ids, context=None):
@@ -44,7 +46,6 @@ class due_list(orm.TransientModel):
              'model': 'account.move.line',
              'form': self.read(cr, uid, ids)[0]
         }
-        print datas
         return {
             'type': 'ir.actions.report.xml',
             'report_name': 'due_list_pdf',

--- a/isa-srl/accounting/account_due_date_report_webkit/wizard/due_list_view.xml
+++ b/isa-srl/accounting/account_due_date_report_webkit/wizard/due_list_view.xml
@@ -9,17 +9,18 @@
             <form string="Print Account Due List Report" version="7.0">
                 <group>
                 	<group>
-                        <field name="company_id" required="1" groups="base.group_multi_company"/>
-                        <field name="type" required="1"/>
-                        <field name="all_partner"/>
+                        <field name="company_id" required="1" groups="base.group_multi_company"/>  
+                        <field name="print_customers"/>
+                        <field name="print_suppliers"/>
                 	</group>
                     <group>
                     	<field name="mode"/>
+                    	<field name="target_move"/>
                         <field name="date_maturity"/>
                     </group>
                 </group>
                 <group>
-                    <field name="partner_ids" attrs="{'invisible':[('all_partner','=',True)]}"/>
+                    <field name="partner_ids"/>
                 </group>
                 <footer>
                     <button name="print_report_pdf" string="Stampa" type="object" class="oe_highlight" />


### PR DESCRIPTION
- Nel wizard per stampa scadenzario, aggiunto campo 'target_move' con selezione di tutte le registrazioni o delle sole registrazioni pubblicate;
- In stampa scadenzario, qualora si sia scelto di stampare le sole registrazioni pubblicate, vengono anche stampate quelle registrazioni riconciliate ma le cui riconciliazioni non sono ancora state pubblicate. In tal caso, tali registrazioni compaiono col valore scaduto/a scadere negativo e tale valore non viene poi sommato ai totali.